### PR TITLE
Exclude checksum from returned value for WifiOpenEVSE

### DIFF
--- a/openevse.py
+++ b/openevse.py
@@ -810,7 +810,7 @@ class WifiOpenEVSE(BaseOpenEVSE):
         """Initialize the connection to the wifi board."""
         import urllib2
         self.hostname = hostname
-        self.regex = re.compile(".*\$(.*\^..).*")
+        self.regex = re.compile(".*\$(.*)\^...*")
 
     def _silent_request(self, *args):
         self._request(*args)


### PR DESCRIPTION
The current regex used to extract the result from the Wifi-returne
HTML includes the RAPI checksum in the value.  This confuses many of
the functions that try to parse the response.  For example, when I
call accumulated_wh(), something like 5920569^1C is extracted.  Then,
the accumulated_wh() function tries to interpret this string as an
int, which raises a ValueError.

This small tweak to the regex moves the checksum out of the match
group, causing it not to be part of the string returned from the
request.