### PR TITLE
Add username/password options to WifiOpenEVSE

### DIFF
--- a/openevse.py
+++ b/openevse.py
@@ -89,6 +89,7 @@ Example:
 >>> print o.current_capacity()
 """
 
+import base64
 import datetime
 import re
 try:
@@ -99,8 +100,6 @@ except ImportError:
 import threading
 import time
 import urllib.request
-import urllib.error
-import urllib.parse
 
 _version = '0.4'
 
@@ -884,12 +883,17 @@ class WifiOpenEVSE(BaseOpenEVSE):
     """A connection to an OpenEVSE equipment through the wifi kit."""
     sync = False
 
-    def __init__(self, hostname):
+    def __init__(self, hostname, username = None, password = None):
         """Initialize the connection to the wifi board."""
         self.hostname = hostname
         # See https://github.com/OpenEVSE/ESP8266_WiFi_v2.x/blob/master/src/html/openevse.js#L70
         # For OpenEVSE's Web UIs version of the regex
         self.regex = re.compile("\\$([^\\^]*)(\\^..)?")
+        if username and password:
+            userpass = '%s:%s' % (username, password)
+            self.base64string = base64.encodebytes(userpass.encode()).decode().rstrip()
+        else:
+            self.base64string = None
 
     def _silent_request(self, *args):
         self._request(*args)
@@ -897,7 +901,10 @@ class WifiOpenEVSE(BaseOpenEVSE):
     def _request(self, *args):
         import json
         url = "http://{host}/r?json=1&rapi=%24{cmd}".format(host=self.hostname, cmd='+'.join(args))
-        resp = urllib.request.urlopen(url)
+        request = urllib.request.Request(url)
+        if self.base64string:
+            request.add_header("Authorization", "Basic %s" % self.base64string)
+        resp = urllib.request.urlopen(request)
         data = json.loads(resp.read())
         if "ret" not in data:
             return False, ""

--- a/openevse.py
+++ b/openevse.py
@@ -893,9 +893,9 @@ class WifiOpenEVSE(BaseOpenEVSE):
         self.regex = re.compile("\\$([^\\^]*)(\\^..)?")
         if username and password:
             userpass = '%s:%s' % (username, password)
-            self.base64auth = base64.encodebytes(userpass.encode()).decode().rstrip()
+            self.authstring = base64.encodebytes(userpass.encode()).decode().rstrip()
         else:
-            self.base64auth = None
+            self.authstring = None
 
     def _silent_request(self, *args):
         self._request(*args)
@@ -904,8 +904,8 @@ class WifiOpenEVSE(BaseOpenEVSE):
         import json
         url = "http://{host}/r?json=1&rapi=%24{cmd}".format(host=self.hostname, cmd='+'.join(args))
         request = urllib.request.Request(url)
-        if self.base64auth:
-            request.add_header("Authorization", "Basic %s" % self.base64auth)
+        if self.authstring:
+            request.add_header("Authorization", "Basic %s" % self.authstring)
         resp = urllib.request.urlopen(request)
         data = json.loads(resp.read())
         if "ret" not in data:

--- a/openevse.py
+++ b/openevse.py
@@ -100,6 +100,8 @@ except ImportError:
 import threading
 import time
 import urllib.request
+import urllib.error
+import urllib.parse
 
 _version = '0.4'
 
@@ -891,9 +893,9 @@ class WifiOpenEVSE(BaseOpenEVSE):
         self.regex = re.compile("\\$([^\\^]*)(\\^..)?")
         if username and password:
             userpass = '%s:%s' % (username, password)
-            self.base64string = base64.encodebytes(userpass.encode()).decode().rstrip()
+            self.base64auth = base64.encodebytes(userpass.encode()).decode().rstrip()
         else:
-            self.base64string = None
+            self.base64auth = None
 
     def _silent_request(self, *args):
         self._request(*args)
@@ -902,8 +904,8 @@ class WifiOpenEVSE(BaseOpenEVSE):
         import json
         url = "http://{host}/r?json=1&rapi=%24{cmd}".format(host=self.hostname, cmd='+'.join(args))
         request = urllib.request.Request(url)
-        if self.base64string:
-            request.add_header("Authorization", "Basic %s" % self.base64string)
+        if self.base64auth:
+            request.add_header("Authorization", "Basic %s" % self.base64auth)
         resp = urllib.request.urlopen(request)
         data = json.loads(resp.read())
         if "ret" not in data:


### PR DESCRIPTION
This change was proposed a long time ago but will still work with adjustments for newer pythons.

```
% python3
Python 3.9.13 | packaged by conda-forge | (main, May 27 2022, 17:00:33)
[Clang 13.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import openevse
>>> o=openevse.WifiOpenEVSE('10.0.0.200')
>>> o.current_capacity()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bmidgley/src/python-openevse/openevse.py", line 374, in current_capacity
    done, data = self._request('GE')
  File "/Users/bmidgley/src/python-openevse/openevse.py", line 907, in _request
    resp = urllib.request.urlopen(request)
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 523, in open
    response = meth(req, response)
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 632, in http_response
    response = self.parent.error(
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 561, in error
    return self._call_chain(*args)
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/Users/bmidgley/miniforge3/lib/python3.9/urllib/request.py", line 641, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 401: Unauthorized
>>> o=openevse.WifiOpenEVSE('10.0.0.200', 'admin', 'xxxxxxxx')
>>> o.current_capacity()
16
>>>
```